### PR TITLE
I've added a table name input for script generation.

### DIFF
--- a/converter/templates/converter/generated_script.html
+++ b/converter/templates/converter/generated_script.html
@@ -41,6 +41,9 @@
 
             <div class="uk-card-footer uk-text-meta">
                 <p><strong>File:</strong> {{ file.file.name }}</p>
+                {% if table_name_used and format != 'json' %}
+                <p><strong>Table/Model Name Used:</strong> {{ table_name_used }}</p>
+                {% endif %}
             </div>
         </div>
 

--- a/converter/templates/converter/preview.html
+++ b/converter/templates/converter/preview.html
@@ -83,6 +83,10 @@
                         {% csrf_token %}
                         <div class="uk-grid-small uk-child-width-auto uk-grid">
                             <div>
+                                <label for="table_name">Table/Model Name:</label>
+                                <input type="text" name="table_name" id="table_name" class="uk-input uk-form-small" placeholder="Enter name" required>
+                            </div>
+                            <div>
                                 <label class="uk-form-label" for="format">Export Format:</label>
                                 <select name="format" id="format" class="uk-select uk-form-small">
                                     <option value="sql">SQL Script</option>

--- a/converter/views.py
+++ b/converter/views.py
@@ -184,6 +184,7 @@ def generate_script(request, file_id):
     file_path = uploaded.file.path
     selected_sheet = uploaded.sheet_name or None
     output_format = request.POST.get('format', 'sql')
+    table_or_model_name = request.POST.get('table_name')
 
     # Ensure the download path exists
     if not os.path.exists(DOWNLOAD_PATH):
@@ -200,12 +201,14 @@ def generate_script(request, file_id):
 
     # Generate the script based on the selected format
     if output_format == 'sql':
-        table_name = 'your_table_name'  # Replace with the actual table name
-        script = generate_sql_script(df, table_name)
+        if not table_or_model_name:
+            table_or_model_name = 'your_table_name'
+        script = generate_sql_script(df, table_or_model_name)
 
     elif output_format == 'orm':
-        model_name = 'YourModel'  # Replace with the actual model name
-        script = generate_orm_script(df, model_name)
+        if not table_or_model_name:
+            table_or_model_name = 'YourModel'
+        script = generate_orm_script(df, table_or_model_name)
 
     elif output_format == 'json':
         script = generate_json_script(df)
@@ -222,6 +225,7 @@ def generate_script(request, file_id):
         'format': output_format,
         'download_url': f"/converter/download/{filename}",
         'file': uploaded,
+        'table_name_used': table_or_model_name,
     })
 
 def download_script(request, filename):


### PR DESCRIPTION
This commit introduces functionality for you to specify a table or model name when generating SQL or ORM scripts.

Key changes:
- I added a 'Table/Model Name' input field to the preview page (`preview.html`).
- I modified the `generate_script` view (`views.py`) to retrieve this name from the form submission and use it in `generate_sql_script` and `generate_orm_script` utility functions.
- I updated the `generated_script.html` template to display the table/model name that was used for the script generation, providing confirmation to you.